### PR TITLE
Hardcoded offset in menu.mod for pageNumber@l might cause problems

### DIFF
--- a/bad1/bad1Data/mod/menu.mod
+++ b/bad1/bad1Data/mod/menu.mod
@@ -236,7 +236,7 @@ MOD_DOL(
             bne-    0b;
 
         addi    r31,r31,1;
-        stw     r31,3576(r5);
+        stw     r31,pageNumber@l(r5);
     0:  lis     r5,-32629;
         blr;
 )


### PR DESCRIPTION
I have not tested whether this change compiles or works properly, but it should. 

In menu.mod, there is a reference to 80000df8 (pageNumber) with a hard-coded address instead of a reference. That causes problems if this is ever moved elsewhere. 